### PR TITLE
Allow path modification for environment reader

### DIFF
--- a/src/cmd/main/main.go
+++ b/src/cmd/main/main.go
@@ -26,7 +26,7 @@ func main() {
 	defer stop()
 
 	// load configuration from .env and/or environment files
-	config := configuration.LoadInto(&Configuration{})
+	config := configuration.LoadInto("", &Configuration{})
 	logger := logging.NewLogger(logging.LoggerOptions{IsProduction: config.IsProduction(), AppName: config.ApplicationName})
 	db := Must(storage.NewDatabase(config.DbConnectionString, logger))
 	clusters := Must(db.GetClusters(ctx))

--- a/src/configuration/configuration_reader.go
+++ b/src/configuration/configuration_reader.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"fmt"
 	"os"
+	"path/filepath"
 	"reflect"
 	"strings"
 )
@@ -129,17 +130,22 @@ func newValueSourceFrom(lines []string) ValueSource {
 	return &inMemoryValueSource{values: envVars}
 }
 
-func NewConfigurationReader() Reader {
+func NewConfigurationReader(relativepath string) Reader {
+	dir, err := os.Getwd()
+	if err != nil {
+		dir = "."
+	}
+	path := filepath.Join(dir, relativepath, "./.env")
 	return &reader{
 		sources: []ValueSource{
-			newValueSourceFrom(readLinesFromFile("./.env")),
+			newValueSourceFrom(readLinesFromFile(path)),
 			&osValueSource{},
 		},
 	}
 }
 
-func LoadInto[T any](cfg T) T {
-	NewConfigurationReader().LoadConfigurationInto(cfg)
+func LoadInto[T any](relativepath string, cfg T) T {
+	NewConfigurationReader(relativepath).LoadConfigurationInto(cfg)
 	return cfg
 }
 

--- a/src/configuration/configuration_reader_test.go
+++ b/src/configuration/configuration_reader_test.go
@@ -1,18 +1,19 @@
 package configuration
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
-type Configuration struct {
+type configuration struct {
 	Foo string `env:"TEST_FOO"`
 	Bar string
 	Baz bool `env:"TEST_BAZ"`
 }
 
 func TestReturnsExpectedWhenReadingTagsFromStruct(t *testing.T) {
-	var cfg = Configuration{}
+	var cfg = configuration{}
 	descriptor := getFieldDescriptorsOf(&cfg)
 
 	assert.Equal(t, "TEST_FOO", descriptor[0].envVarName)
@@ -24,7 +25,7 @@ func TestReader_LoadConfigurationInto_InsertsExpectedValuesFromValueSource(t *te
 		&inMemoryValueSource{map[string]string{"TEST_FOO": "REAL_FOO_VALUE", "TEST_BAZ": "1"}},
 	}}
 
-	var cfg = Configuration{}
+	var cfg = configuration{}
 	reader.LoadConfigurationInto(&cfg)
 
 	assert.Equal(t, "REAL_FOO_VALUE", cfg.Foo)


### PR DESCRIPTION
When running programs, the working directory is critical to the location of the .env-file.
This is fine when running the main program, as the hard-coded string matched the main-file location.

However, when testing, the CWD is determined by the individual test in question, making the configuration loader fail to find any environment variables.

This change allows for overwriting this default.

Note: I do not think this is a good way of reading environment variables in general.
However, I do not think it is worth rewriting all of that at this time.
Maybe I'll return to that once the consumer-task is done proper.

