### PR TITLE
Allow path modification for environment reader

### DIFF
--- a/src/cmd/main/main.go
+++ b/src/cmd/main/main.go
@@ -26,7 +26,7 @@ func main() {
 	defer stop()
 
 	// load configuration from .env and/or environment files
-	config := configuration.LoadInto(&configuration.Configuration{})
+	config := configuration.LoadInto("", &configuration.Configuration{})
 	logger := logging.NewLogger(logging.LoggerOptions{IsProduction: config.IsProduction(), AppName: config.ApplicationName})
 	db := Must(storage.NewDatabase(config.DbConnectionString, logger))
 	clusters := Must(db.GetClusters(ctx))

--- a/src/configuration/configuration_reader.go
+++ b/src/configuration/configuration_reader.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"fmt"
 	"os"
+	"path/filepath"
 	"reflect"
 	"strings"
 )
@@ -129,17 +130,22 @@ func newValueSourceFrom(lines []string) ValueSource {
 	return &inMemoryValueSource{values: envVars}
 }
 
-func NewConfigurationReader() Reader {
+func NewConfigurationReader(relativepath string) Reader {
+	dir, err := os.Getwd()
+	if err != nil {
+		dir = "."
+	}
+	path := filepath.Join(dir, relativepath, "./.env")
 	return &reader{
 		sources: []ValueSource{
-			newValueSourceFrom(readLinesFromFile("./.env")),
+			newValueSourceFrom(readLinesFromFile(path)),
 			&osValueSource{},
 		},
 	}
 }
 
-func LoadInto[T any](cfg T) T {
-	NewConfigurationReader().LoadConfigurationInto(cfg)
+func LoadInto[T any](relativepath string, cfg T) T {
+	NewConfigurationReader(relativepath).LoadConfigurationInto(cfg)
 	return cfg
 }
 

--- a/src/configuration/configuration_reader_test.go
+++ b/src/configuration/configuration_reader_test.go
@@ -1,8 +1,9 @@
 package configuration
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 type TestConfiguration struct {

--- a/src/functional_tests/.env
+++ b/src/functional_tests/.env
@@ -1,4 +1,0 @@
-CG_APPLICATION_NAME=Confluent Gateway Local Test
-CG_ENVIRONMENT=Test
-CG_DB_CONNECTION_STRING=host=localhost user=postgres password=p dbname=db port=5432 sslmode=disable
-CG_TOPIC_NAME_PROVISIONING=cloudengineering.confluentgateway.provisioning

--- a/src/functional_tests/tester_app.go
+++ b/src/functional_tests/tester_app.go
@@ -3,6 +3,8 @@ package main
 import (
 	"context"
 	"fmt"
+	"time"
+
 	"github.com/dfds/confluent-gateway/configuration"
 	"github.com/dfds/confluent-gateway/functional_tests/mocks"
 	"github.com/dfds/confluent-gateway/internal/confluent"
@@ -12,7 +14,6 @@ import (
 	"github.com/dfds/confluent-gateway/logging"
 	"gorm.io/driver/postgres"
 	"gorm.io/gorm"
-	"time"
 )
 
 // from db/seed/cluster.csv TODO: figure out how to set it up in a better way
@@ -52,7 +53,7 @@ func newTesterApp(logger logging.Logger, config *configuration.Configuration, db
 }
 
 func CreateAndSetupTester(logger logging.Logger) (*TesterApp, error) {
-	config := configuration.LoadInto(&configuration.Configuration{})
+	config := configuration.LoadInto("../", &configuration.Configuration{})
 
 	db, err := storage.NewDatabase(config.DbConnectionString, logger)
 	if err != nil {


### PR DESCRIPTION
When running programs, the working directory is critical to the location of the .env-file.
This is fine when running the main program, as the hard-coded string matched the main-file location.

However, when testing, the CWD is determined by the individual test in question, making the configuration loader fail to find any environment variables.

This change allows for overwriting this default.

Note: I do not think this is a good way of reading environment variables in general.
However, I do not think it is worth rewriting all of that at this time.
Maybe I'll return to that once the consumer-task is done proper.