### PR TITLE
Build app in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,10 @@
+FROM golang:1.21 as build
+
+COPY src/ /src
+WORKDIR /src
+RUN go mod download
+RUN CGO_ENABLED=0 go build github.com/dfds/confluent-gateway/cmd/main
+
 FROM alpine
 
 # ADD Curl
@@ -17,6 +24,6 @@ RUN adduser \
 USER app
 
 WORKDIR /app
-COPY ./.output/app ./
+COPY --from=build /src/main /app/confluent-gateway
 
-ENTRYPOINT [ "./confluent-gateway" ]
+ENTRYPOINT [ "/app/confluent-gateway" ]


### PR DESCRIPTION
Build confluent-gateway within the build container for the Dockerfile, rather than building it on the host machine and the copying it into the final container image.

Done as part of https://github.com/dfds/cloudplatform/issues/1893
