### PR TITLE
Update trigger_shared_generate_pr.yaml

### DIFF
--- a/.github/workflows/trigger_shared_generate_pr.yaml
+++ b/.github/workflows/trigger_shared_generate_pr.yaml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   shared:
-    uses: dfds/shared-workflows/.github/workflows/automation-create-pull-request.yaml@master
+    uses: dfds/shared-workflows/.github/workflows/automation-create-pull-request.yaml@v2.0.1
     with:
       repository-name: ${{ github.repository }}
       main-branch: main


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow to use a specific version of a shared workflow instead of tracking the `master` branch. This change helps ensure stability and reproducibility by locking the workflow to version `v2.0.1`.

Workflow stability improvement:

* Updated the `shared` job in `.github/workflows/trigger_shared_generate_pr.yaml` to use `dfds/shared-workflows/.github/workflows/automation-create-pull-request.yaml@v2.0.1` instead of tracking the `master` branch.